### PR TITLE
Update wording in VSCode_setup_guide.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,34 @@ To get the most out of the hackathon exercises, we recommend using Microsoft Vis
 - watch our getting started workflow for Gadi video tutorial [here](https://youtu.be/fSxirzDR3iw) (6 min),
 - follow our step-by-step getting started documentation [here](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md).
 
-## Getting Started
+## Logging into Gadi
 
-The first thing to do is setup our system to run the ESMValTool recipes prepared for the Hackathon. 
+The first thing to do is to login to Gadi. You can choose to run the following commands either from your computer's terminal or from the terminal within VS Code. If you follow the above steps to set up VS Code on Gadi, you can skip to the next section ["Set up our environment to run ESMValTool"](#set-up-our-environment-to-run-ESMValTool) below (since the [video](https://youtu.be/fSxirzDR3iw) and [step-by-step guide](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md) already walk you through how to connect to Gadi in VS Code). 
 
-**Step 1.** Log into Gadi using ssh via the command line using your registed NCI *username* and enter your password when prompted. Once you see the welcome note you have successfully logged in. 
+Log into Gadi using ssh via the command line using your registed NCI *username* and enter your password when prompted. Once you see the welcome note you have successfully logged in. 
 ```
 $ ssh [username]@gadi.nci.org.au
 ```
-**Step 2.** Enter the following two commands (one after the other). The first command loads some necessary dependencies needed to run ESMValTool, and the second command loads the required [ACCESS-NRI ESMValTool-workflow](https://github.com/ACCESS-NRI/ESMValTool-workflow) module.
+## Set up our environment to run ESMValTool 
+
+Next we want to set up our system to run the ESMValTool recipes prepared for the Hackathon. 
+
+**Step 1.** Enter the following two commands (one after the other). The first command loads some necessary dependencies needed to run ESMValTool, and the second command loads the required [ACCESS-NRI ESMValTool-workflow](https://github.com/ACCESS-NRI/ESMValTool-workflow) module.
 ```
 module use /g/data/xp65/public/modules
 ```
 ```
 module load esmvaltool
 ```
-**Step 3.** Run the hackathon setup script. This verifies that your NCI account has access to the required projects on Gadi and that their respective storage locations are mounted, clones the [CMIP7-Hackathon Github repository](https://github.com/ACCESS-NRI/CMIP7-Hackathon), and automatically runs each of the hackathon ESMValTool recipes as a PBS job on Gadi.
+**Step 2.** Run the hackathon setup script from any directory. This verifies that your NCI account has access to the required projects on Gadi and that their respective storage locations are mounted, clones the [CMIP7-Hackathon Github repository](https://github.com/ACCESS-NRI/CMIP7-Hackathon), and automatically runs each of the hackathon ESMValTool recipes as PBS jobs on Gadi.
 ```
 check_hackathon
 ```
-Note that this may take up to a minute to finish running.
+You will see a range of checks and processes print to the screen, which may take up to 1 minute to complete. Once you see the "YOU ARE ALL SET!!!" message, everything is setup and ready to go.
 
 ## ESMValTool recipes
 
-Once you have run `check_hackathon` and have recieved the "YOU ARE ALL SET!!!" message in your chosen terminal, you can now do the following:
+You have just started running a suite of ESMValTool recipes! You can now do any of the following:
 
 * Check the status of each of your actively running recipes:
 ```
@@ -41,7 +45,7 @@ qstat -u [username]
 ```
 /scratch/nf33/[username]/esmvaltool_outputs
 ```
-* View ESMValTool recipe logs here:
+* View ESMValTool recipe log files here:
 ```
 /scratch/nf33/[username]/CMIP7-Hackathon/admin/logs
 ```

--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@ Welcome to the ACCESS-NRI CMIP7 Hackathon repo.
 
 ## Visual Studio Code
 
-To get the most out of the hackathon exercises, we recommend using Microsoft Visual Studio Code which can be downloaded free for Windows, MacOS and Linux [here](https://code.visualstudio.com/). Additionally, for new VS Code users or those simply wanting a quick refresher, you can;
-- watch our getting started workflow for Gadi video tutorial [here](https://youtu.be/fSxirzDR3iw) (6 min),
-- follow our step-by-step getting started documentation [here](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md).
+To get the most out of the hackathon exercises, we recommend using Microsoft Visual Studio Code which can be downloaded free for Windows, MacOS and Linux [here](https://code.visualstudio.com/). For new VS Code users or those simply wanting a quick refresher, we have created a video and written guide to help you set up VS Code on Gadi. Note that the information is roughly the same, so you can choose either video or written guide to follow along.
+- [Video tutorial: Visual Studio Code Workflow for Gadi](https://youtu.be/fSxirzDR3iw) _(~6 min)_
+- [Written guide: Getting Started Guide for Visual Studio Code with Gadi](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md)
+
+
+_**NOTE:** There are two pieces of information to clarify from the video tutorial that are explained in the written guide:_
+1. _When logging into Gadi for the first time in VS Code, you do not need to write your own config file. You can simply choose the default option that is suggested and VS Code will create one for you. You only need to do this once - the first time you log in._
+2. _In addition to the 3 extensions mentioned in the video, you will need to install a 4th extension to view html files (this is how most of the ESMValTool recipes show output plots). You can see our recommended extension "Live Server" in the [written guide above](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md)._
+
 
 ## Logging into Gadi
 
-The first thing to do is to login to Gadi. You can choose to run the following commands either from your computer's terminal or from the terminal within VS Code. If you follow the above steps to set up VS Code on Gadi, you can skip to the next section ["Set up our environment to run ESMValTool"](#set-up-our-environment-to-run-ESMValTool) below (since the [video](https://youtu.be/fSxirzDR3iw) and [step-by-step guide](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md) already walk you through how to connect to Gadi in VS Code). 
+The first thing to do is to login to Gadi. You can choose to run the following commands either from your computer's terminal or from the terminal within VS Code. If you follow the above steps to set up VS Code on Gadi, you can skip to the next section ["Set up our environment to run ESMValTool"](#set-up-our-environment-to-run-ESMValTool) below (since the [video](https://youtu.be/fSxirzDR3iw) and [written guide](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md) already walk you through how to connect to Gadi in VS Code). 
 
 Log into Gadi using ssh via the command line using your registed NCI *username* and enter your password when prompted. Once you see the welcome note you have successfully logged in. 
 ```

--- a/docs/VSCode_setup_guide.md
+++ b/docs/VSCode_setup_guide.md
@@ -1,5 +1,5 @@
-# Getting started guide for Visual Studio Code
-<p>This is an introductory guide to setting up and using Microsoft Visual Studio Code to interact with Gadi and run ESMValTool recipes for the ACCESS-NRI CMIP7-Hackathon.</p>
+# Getting started guide for Visual Studio Code (VS Code)
+<p>This is an introductory guide to setting up and using Microsoft Visual Studio Code (often referred to as VS Code) to interact with Gadi and run ESMValTool recipes for the ACCESS-NRI CMIP7-Hackathon.</p>
 
 ## Quick-links to sections
 - [0. Pre-Workshop preparation](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md#0-pre-workshop-preparation)
@@ -14,38 +14,38 @@
 - *0.1* In order to get the most out of the Hackathon, you will require a NCI account. If you do not yet have a NCI account, you can sign up on the [MyNCI website](https://my.nci.org.au).
 - *0.2* To run the exercises, access to specific projects on Gadi is required. To help things run as smoothly as possible on the day, please log in to the [MyNCI website](https://my.nci.org.au) and join the following projects:
 `nf33`, `xp65`, `fs38`, `oi10`, `al33`, `rr3`, `rt52`, `zz93` and `ct11` **prior** to attending the Hackathon. Please note it can take 1-2 days to receive membership approvals.
-- *0.3* Download and install Microsoft Visual Studio on your local system. VS Code can be downloaded from [this page](https://code.visualstudio.com/).
+- *0.3* Download and install Microsoft Visual Studio Code on your local system. VS Code can be downloaded from [this page](https://code.visualstudio.com/).
 
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md#getting-started-guide-for-visual-studio-code)
 
 ## 1. Installing VS Code extensions
 Out of the box, VS Code doesn't do everything we need it to - so we must install some software extensions to get the most out of the Hackathon.
 
-- *1.1* When VS Code starts up, you are greeting with a GUI that looks like this. The first thing we need to do is click the extensions icon in the left-hand navigation pane marked below with the red ellipse.
+- *1.1* When VS Code starts up, you are greeted with a GUI that looks like this. The first thing we need to do is click the extensions icon in the left-hand navigation pane marked below with the red ellipse.
 
 <p align="center"><img src="assets/extensions.png" alt="drawing" width="90%"/></p>
 
 We have a total of 4 extensions to install. Note that when hovering over a listed extension, a small information pane pops up, and clicking on an extension opens a full extension information page.
 
-- *Extension 1:* **Python** <br>
-This extension provides full code support and highlighting for the *Python* programming language within VS Code. Type `python` into the extensions search bar and select the *Python* extension published by Microsoft marked with the red ellipse below. Click `install` to add the extension.
-
-<p align="center"><img src="assets/extensions_python.png" alt="drawing" width="90%"/></p>
-
-- *Extension 2:* **Jupyter** <br>
-This extension allows us to view, edit and run *Jupyter Notebooks* within VS Code. Type `jupyter` into the extensions search bar and select the *Jupyter* extension published by Microsoft marked with the red ellipse below. Click `install` to add the extension.
-
-<p align="center"><img src="assets/extensions_jupyter.png" alt="drawing" width="90%"/></p>
-
-- *Extension 3:* **Remote-SSH** <br>
-This extension allows us to securely login in remote servers, in our case NCI Gadi, using *ssh*. Type `remote ssh` into the extensions search bar and select the *Remote-SSH* extension published by Microsoft marked with the red ellipse below. Click `install` to add the extension.
+- *Extension 1:* **Remote-SSH** <br>
+This extension allows us to securely login to remote servers, in our case NCI Gadi, using *ssh*. Type `remote ssh` into the extensions search bar and select the *Remote-SSH* extension published by Microsoft marked with the red ellipse below. Click `install` to add the extension.
 
 <p align="center"><img src="assets/extensions_ssh.png" alt="drawing" width="90%"/></p>
 
-- *Extension 4:* **Live Server** <br>
-Type `live server` into the extensions search bar and select the *Live Server* extension published by Ritwick Dey marked with the red ellipse below. Click `install` to add the extension.
+- *Extension 2:* **Live Server** <br>
+Type `live server` into the extensions search bar and select the *Live Server* extension published by Ritwick Dey marked with the red ellipse below. This extension allows us to preview html files from a browser on our computer, and will update automatically as the html file is updated in VS Code. We will use this extension to preview some of the ESMValTool recipe outputs that come in html format. Click `install` to add the extension.
 
 <p align="center"><img src="assets/extensions_liveserver.png" alt="drawing" width="90%"/></p>
+
+- *Extension 3:* **Python** *(Optional)* <br>
+This extension provides full code support and highlighting for the *Python* programming language within VS Code. Type `python` into the extensions search bar and select the *Python* extension published by Microsoft marked with the red ellipse below. This extension will be helpful if you want to edit any Python files associated with ESMValTool recipes. Click `install` to add the extension.
+
+<p align="center"><img src="assets/extensions_python.png" alt="drawing" width="90%"/></p>
+
+- *Extension 4:* **Jupyter** *(Optional)* <br>
+This extension allows us to view, edit and run *Jupyter Notebooks* within VS Code. Type `jupyter` into the extensions search bar and select the *Jupyter* extension published by Microsoft marked with the red ellipse below. This extension will be helpful if you prefer to use Jupyter Notebooks when editing code in VS Code. Click `install` to add the extension.
+
+<p align="center"><img src="assets/extensions_jupyter.png" alt="drawing" width="90%"/></p>
 
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md#getting-started-guide-for-visual-studio-code)
 
@@ -65,7 +65,7 @@ To connect to Gadi, follow these steps to establish and open a remote connection
 
 <p align="center"><img src="assets/open_remote3.png" alt="drawing" width="90%"/></p>
 
-- *2.4* Enter the remote host (Gadi) details which are comprised of your NCI `username` followed by `@gadi.nci.org.au`. You may be prompted to select a _ssh_ `config` file so VS Code can remember your _ssh_ connections in future. Usually the first option works fine as VS Code will manage the file.
+- *2.4* Enter the remote host (Gadi) details which are comprised of your NCI `username` followed by `@gadi.nci.org.au`. You may be prompted to select a _ssh_ `config` file so VS Code can remember your _ssh_ connections in future. VS Code will automatically create a config file for you, so usually selecting the first default option that appears will work fine as VS Code will manage the file.
 
 <p align="center"><img src="assets/open_remote4.png" alt="drawing" width="90%"/></p>
 
@@ -77,7 +77,7 @@ To connect to Gadi, follow these steps to establish and open a remote connection
 
 ## 3. Load ESMValTool modules and set up Hackathon environment
 
-To load all required ESMValTool and [ACCESS-NRI ESMValTool-workflow](https://github.com/ACCESS-NRI/ESMValTool-workflow) components, please enter the following two commands (one after the other) in the terminal from any directory:
+To load all required ESMValTool and [ACCESS-NRI ESMValTool-workflow](https://github.com/ACCESS-NRI/ESMValTool-workflow) components, please enter the following two commands (one after the other) in the VS Code terminal from any directory:
 
 ```
 module use /g/data/xp65/public/modules [then press ENTER/RETURN]
@@ -87,11 +87,11 @@ followed by:
 module load esmvaltool [then press ENTER/RETURN]
 ```
 
-To set up the Hackathon environment (check project membership, mount required storage, created working folders and clone the Hackathon Github repository), please enter the following command in the terminal from any directory:
+To set up the Hackathon environment (check project membership, mount required storage, create working folders, clone the Hackathon Github repository), please enter the following command in the terminal from any directory:
 ```
 check_hackathon [then press ENTER/RETURN]
 ```
-You will see a range of checks and processes print to the screen. Once you see the "YOU ARE ALL SET!!!" message, everything is setup and ready to go.
+You will see a range of checks and processes print to the screen, which may take up to 1 minute to complete. Once you see the "YOU ARE ALL SET!!!" message, everything is setup and ready to go.
 <br><br>
 This process also creates and runs a PBS job on Gadi for each of the Hackathon example ESMValTool recipes. To check the status of these jobs enter the following into the terminal - where [username] is your NCI account username.
 ```
@@ -99,7 +99,7 @@ qstat -u [username]
 ```
 This will list all currently running ESMValTool recipes.
 <br><br>
-For each, recipe outputs can be found in:
+For each recipe, the outputs can be found in:
 ```
 /scratch/nf33/[username]/esmvaltool_outputs
 ```
@@ -145,7 +145,7 @@ You can add multiple unique folders to the current workspace by right clicking a
 
 <p align="center"><img src="assets/workspace4.png" alt="drawing" width="90%"/></p>
 
-Now that you have a workspace setup, why not add the above mentioned `esmvaltool_outputs` and `logs` folders (replacing [username] with your NCI account username) for quick access.
+Now that you have a workspace setup, we suggest adding the above mentioned `esmvaltool_outputs` and `logs` folders (replacing [username] with your NCI account username) for quick access.
 
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md#getting-started-guide-for-visual-studio-code)
 

--- a/docs/VSCode_setup_guide.md
+++ b/docs/VSCode_setup_guide.md
@@ -77,52 +77,8 @@ To connect to Gadi, follow these steps to establish and open a remote connection
 
 ## 3. Load ESMValTool modules and set up Hackathon environment
 
-To load all required ESMValTool and [ACCESS-NRI ESMValTool-workflow](https://github.com/ACCESS-NRI/ESMValTool-workflow) components, please enter the following two commands (one after the other) in the VS Code terminal from any directory:
+You can now follow the instructions in the [README](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/README.md) for how to setup your environment to run ESMValTool and how to use ESMValTool recipes. To continue to Step 4 below, you must have at least run the steps under the heading [Set up our environment to run ESMValTool](https://github.com/paigem/CMIP7-Hackathon/blob/main/README.md#set-up-our-environment-to-run-esmvaltool), as these steps will create the folders that we will open below.
 
-```
-module use /g/data/xp65/public/modules [then press ENTER/RETURN]
-```
-followed by:
-```
-module load esmvaltool [then press ENTER/RETURN]
-```
-
-To set up the Hackathon environment (check project membership, mount required storage, create working folders, clone the Hackathon Github repository), please enter the following command in the terminal from any directory:
-```
-check_hackathon [then press ENTER/RETURN]
-```
-You will see a range of checks and processes print to the screen, which may take up to 1 minute to complete. Once you see the "YOU ARE ALL SET!!!" message, everything is setup and ready to go.
-<br><br>
-This process also creates and runs a PBS job on Gadi for each of the Hackathon example ESMValTool recipes. To check the status of these jobs enter the following into the terminal - where [username] is your NCI account username.
-```
-qstat -u [username]
-```
-This will list all currently running ESMValTool recipes.
-<br><br>
-For each recipe, the outputs can be found in:
-```
-/scratch/nf33/[username]/esmvaltool_outputs
-```
-and associated log files can be found in:
-```
-/scratch/nf33/[username]/MIP7-Hackathon/admin/logs
-```
-The full cloned [CMIP7-Hackathon Github repository](https://github.com/ACCESS-NRI/CMIP7-Hackathon) can be found here:
-```
-/scratch/nf33/[username]/CMIP7-Hackathon
-```
-We also include a convenience wrapper function to manually run individual recipes found in the CMIP7-Hackathon Github repository [recipes directory](https://github.com/ACCESS-NRI/CMIP7-Hackathon/tree/main/recipes):
-```
-run_recipe [path-to-recipe]
-```
-For example, to manually run the hackathon `map1` recipe found in `/scratch/nf33/[username]/CMIP7-Hackathon/recipes/ocean/maps`, you can `cd` into the cloned CMIP7-Hackathon Github repository
-```
-cd /scratch/nf33/[username]/CMIP7-Hackathon
-```
-and run the following:
-```
-run_recipe recipes/ocean/maps/map1.yml
-```
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/VSCode_setup_guide.md#getting-started-guide-for-visual-studio-code)
 
 ## 4. Create a workspace / open folders on Gadi


### PR DESCRIPTION
Thanks @headmetal for creating this guide - it looks really great!

I made a few suggested updates in hopes of clarifying the steps:
- I re-ordered the extensions since (to me) the Remote SSH and Live Server are the most important for the hackathon. I added "Optional" to Python and Jupyter. I also added more language as to why these extensions are useful for us at the hackathon.
- I tried to clarify the language around when VS Code asks for a config file. In the video, the language made it sound like users have to create their own config file (and we got a question about that in the drop-in session), so I tried to help clarify that in this guide. (We may want to flag this somewhere more noticeable in the README as well, since the video language is unclear - or edit the video?)
- I made the language around suggesting to open other folders in VS Code more firm. Since one of the main aspects of our ESMValTool demo will be to have participants open up and look at the outputs from the "check_hackathon" command, we wan to make sure that folks have an easy way to access the `esmvaltool_outputs` folder.
- Minor wording fixes for clarity

I have a few other clarifying questions that I will likely post in Slack to get input on before making any suggested updates in GitHub.