### PR TITLE
Minor wording tweaks to the ARE setup guides

### DIFF
--- a/docs/ARE_VDI_setup_guide.md
+++ b/docs/ARE_VDI_setup_guide.md
@@ -1,5 +1,5 @@
 # ACCESS-NRI CMIP7-Hackathon ARE Virtual Desktop (VDI) setup guide
-<p>Quick-start guide to setting up a JupyterLab session using the Australian Research Environment to run the ACCESS-NRI CMIP7-Hackathon exercises.</p>
+<p>Quick-start guide to setting up a virtual desktop (VDI) session using the Australian Research Environment (ARE) to run the ACCESS-NRI CMIP7-Hackathon exercises.</p>
 
 ## Quick-links to sections
 - [0. Pre-Workshop preparation](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/ARE_VDI_setup_guide.md#0-pre-workshop-preparation)

--- a/docs/ARE_VDI_setup_guide.md
+++ b/docs/ARE_VDI_setup_guide.md
@@ -32,7 +32,7 @@ Click on `Virtual Desktop` under *Featured Apps* to configure a new VDI instance
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/ARE_VDI_setup_guide.md#access-nri-cmip7-hackathon-are-virtual-desktop-vdi-setup-guide)
 
 ## 3. Configure VDI session
-You will now be presented with the main JupyterLab instance configuration form. Please complete **only** the fields below - leave all other fields blank or to their default values.
+You will now be presented with the main VDI instance configuration form. Please complete **only** the fields below - leave all other fields blank or to their default values.
 
 - *3.1* **Walltime**: The number of hours the VDI instance will run. For the hackathon, please insert a walltime of `4` hours.
 
@@ -46,14 +46,14 @@ You will now be presented with the main JupyterLab instance configuration form. 
 
 <p align="center"><img src="assets_VDI/project.png" alt="drawing" width="60%"/></p>
 
-- *3.4* **Storage**: This is the list of project data storage locations required to complete the hackathon exercises. In ARE, storage locations need to be explicitly defined to access these data from within a VDI instance. Please copy and paste the following string listing into the storage input field:
+- *3.4* **Storage**: This is the list of project data storage locations required to complete the hackathon exercises. In ARE, storage locations need to be explicitly defined to access these data from within a VDI instance. Please copy and paste the following string in its entirety into the storage input field:
 ```
 scratch/nf33+gdata/nf33+gdata/xp65+gdata/fs38+gdata/oi10+gdata/al33+gdata/rr3+gdata/rt52+gdata/zz93+gdata/ct11
 ```
 
 <p align="center"><img src="assets_VDI/project.png" alt="drawing" width="60%"/></p>
 
-- *3.5* Click `Launch` to start your JupyterLab instance.
+- *3.5* Click `Launch` to start your VDI instance.
 
 
 <p align="center"><img src="assets_ARE/launch.png" alt="drawing" width="60%"/></p>
@@ -65,20 +65,20 @@ Once you have clicked `Launch` the browser will redirect to the 'interactive ses
 
 <p align="center"><img src="assets_VDI/queue.png" alt="drawing" width="60%"/></p>
 
-Once the VDI instance has started (this usually takes around 30 seconds) and this status window should update and look something like the following, reporting that the instance has started and the time remaining. More detailed information on the instance can be accessed by clicking the `Session ID` link.
+Once the VDI instance has started (this usually takes around 30 seconds), this status window should update and look something like the following, reporting that the instance has started and the time remaining. More detailed information on the instance can be accessed by clicking the `Session ID` link.
 
 Additionally there are extra streaming performance related controls here for both `Compression` and `Image Quality`. Generally the default settings here work fine, but if you are having trouble you can adjust these parameters.
 
 <p align="center"><img src="assets_VDI/running.png" alt="drawing" width="60%"/></p>
 
-Click `Launch VDI Desktop`. This opens the VDI instance a new browser window where you can navigate to the location of the cloned tutorial files.
+Click `Launch VDI Desktop`. This opens the VDI instance in a new browser window where you can navigate to the location of the cloned tutorial files.
 
 Depending on which browser you are using, a prompt can appear in the browser at VDI startup stating that ARE is requesting access to your computer clipboard. This is optional, but allowing this access can make transferring copied text and files between your computer and the VDI instance much easier!
 
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/ARE_VDI_setup_guide.md#access-nri-cmip7-hackathon-are-virtual-desktop-vdi-setup-guide)
 
 ## 5. Setup Hackathon ESMValTool environment and run recipes
-To finalise the system setup, we must run the hackathon setup scripts. These load the required ESMValTool-workflow dependencies, verify that your NCI account has access to the required projects on Gadi and that their respective storage locations are mounted, clones the [CMIP7-Hackathon Github repository](https://github.com/ACCESS-NRI/CMIP7-Hackathon), and automatically runs each of the hackathon ESMValTool recipes as PBS jobs on Gadi.
+To finalise the system setup, we must run the hackathon setup scripts. The setup script loads the required ESMValTool-workflow dependencies, verifies that your NCI account has access to the required projects on Gadi and that their respective storage locations are mounted, clones the [CMIP7-Hackathon Github repository](https://github.com/ACCESS-NRI/CMIP7-Hackathon), and automatically runs each of the hackathon ESMValTool recipes as PBS jobs on Gadi.
 
 To do this within VDI, from the top menu we must first open `Terminal` by clicking on the small computer screen icon shown in red below:
 

--- a/docs/ARE_setup_guide.md
+++ b/docs/ARE_setup_guide.md
@@ -46,7 +46,7 @@ You will now be presented with the main JupyterLab instance configuration form. 
 
 <p align="center"><img src="assets_ARE/project.png" alt="drawing" width="60%"/></p>
 
-- *3.4* **Storage**: This is the list of project data storage locations required to complete the hackathon exercises. In ARE, storage locations need to be explicitly defined to access these data from within a JupyterLab instance. Please copy and paste the following string listing into the storage input field:
+- *3.4* **Storage**: This is the list of project data storage locations required to complete the hackathon exercises. In ARE, storage locations need to be explicitly defined to access these data from within a JupyterLab instance. Please copy and paste the following string in its entirety into the storage input field:
 ```
 scratch/nf33+gdata/nf33+gdata/xp65+gdata/fs38+gdata/oi10+gdata/al33+gdata/rr3+gdata/rt52+gdata/zz93+gdata/ct11
 ```
@@ -82,11 +82,11 @@ Once you have clicked `Launch` the browser will redirect to the 'interactive ses
 
 <p align="center"><img src="assets_ARE/queue.png" alt="drawing" width="60%"/></p>
 
-Once the JupyterLab instance has started (this usually takes around 30 seconds) and this status window should update and look something like the following, reporting that the instance has started and the time remaining. More detailed information on the instance can be accessed by clicking the `Session ID` link.
+Once the JupyterLab instance has started (this usually takes around 30 seconds), this status window should update and look something like the following, reporting that the instance has started and the time remaining. More detailed information on the instance can be accessed by clicking the `Session ID` link.
 
 <p align="center"><img src="assets_ARE/running.png" alt="drawing" width="60%"/></p>
 
-Click `Open JupyterLab`. This opens the instance a new browser window where you can navigate to the location of the cloned tutorial files.
+Click `Open JupyterLab`. This opens the instance in a new browser window where you can navigate to the location of the cloned tutorial files.
 
 [\[Back to top\]](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/ARE_setup_guide.md#access-nri-cmip7-hackathon-are-setup-guide)
 

--- a/docs/ARE_setup_guide.md
+++ b/docs/ARE_setup_guide.md
@@ -1,5 +1,5 @@
 # ACCESS-NRI CMIP7-Hackathon ARE setup guide
-<p>Quick-start guide to setting up a JupyterLab session using the Australian Research Environment to run the ACCESS-NRI CMIP7-Hackathon exercises.</p>
+<p>Quick-start guide to setting up a JupyterLab session using the Australian Research Environment  to run the ACCESS-NRI CMIP7-Hackathon exercises.</p>
 
 ## Quick-links to sections
 - [0. Pre-Workshop preparation](https://github.com/ACCESS-NRI/CMIP7-Hackathon/blob/main/docs/ARE_setup_guide.md#0-pre-workshop-preparation)


### PR DESCRIPTION
These look great @headmetal! I just noticed a bit of wording that could be cleaned up, mostly around the correct usage of "JupyterLab" vs "VDI". 